### PR TITLE
Support for remote database server plus fix for cron that causes chef run failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ Attributes
 * `node['otrs']['kernel_config']['email']` - Admin email address.
 * `node['otrs']['kernel_config']['system_id']` - System ID that should be more or less unique.
 
-* `node['otrs']['database']['host']` - Database host
-* `node['otrs']['database']['user']` - Database user
-* `node['otrs']['database']['password']` - Database password
+* `node['otrs']['database']['host']` - Database host default localhost 
+* `node['otrs']['database']['user']` - Database user used by OTRS application
+* `node['otrs']['database']['password']` - Database password by OTRS application
 * `node['otrs']['database']['name']` - Database name
+* `node['otrs']['database']['dba_user']` - Database dba user used for database creation
+* `node['otrs']['database']['dba_password']` - Database dba password used for database create
 
 
 Usage
@@ -61,10 +63,11 @@ TODO
  * Next time (weird thing) the Apache restart command exits unclean, although everything is fine.
  * **I'm looking forward to your help on how to fix both of them!**
 
+
 Change Log
 ==========
 
-###0.8.0
+###0.9.0
 
 * Initial version published
 	

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,6 +12,8 @@ default['otrs']['database']['host'] = "localhost"
 default['otrs']['database']['user'] = "otrs"
 default['otrs']['database']['password'] = nil
 default['otrs']['database']['name'] = "otrs"
+default['otrs']['database']['dba_user'] = "root"
+default['otrs']['database']['dba_password'] = "password"
 
 default['otrs']['kernel_config']['email'] = "otrs@otrs.example.org"
 default['otrs']['kernel_config']['organization'] = "Example Association"

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "steffen.gebert@typo3.org"
 license          "Apache 2.0"
 description      "Installs/Configures OTRS"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.8.0"
+version          "0.9.0"
 
 depends "perl"
 depends "apache2"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -111,7 +111,7 @@ include_recipe "database"
 ::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
 node.set_unless['otrs']['database']['password'] = secure_password
 
-mysql_connection_info = {:host => "localhost", :username => 'root', :password => node['mysql']['server_root_password']}
+mysql_connection_info = {:host => node['otrs']['database']['host'], :username => 'root', :password => node['mysql']['server_root_password']}
 
 
 begin
@@ -120,7 +120,7 @@ begin
   end
   Gem.clear_paths  
   require 'mysql'
-  m=Mysql.new("localhost","root",node['mysql']['server_root_password']) 
+  m=Mysql.new(node['otrs']['database']['host'],"root",node['mysql']['server_root_password']) 
 
   if m.list_dbs.include?("otrs") == false
     # create otrs database

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -322,6 +322,7 @@ end
 
 cron "DeleteSessionIDs" do
   hour "0"
+  minute "5"
   command "#{node.otrs.prefix}/otrs/bin/otrs.DeleteSessionIDs.pl --expired >> /dev/null"
   user "otrs"
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -322,7 +322,6 @@ end
 
 cron "DeleteSessionIDs" do
   hour "0"
-  minute ""
   command "#{node.otrs.prefix}/otrs/bin/otrs.DeleteSessionIDs.pl --expired >> /dev/null"
   user "otrs"
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -103,15 +103,20 @@ end
 
 # Install MySQL server
 
-include_recipe "mysql::server"
+#include_recipe "mysql::server"
 include_recipe "mysql::client"
 include_recipe "database"
 
 # generate the password
-::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
-node.set_unless['otrs']['database']['password'] = secure_password
+#::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
+#node.set_unless['otrs']['database']['password'] = secure_password
 
-mysql_connection_info = {:host => node['otrs']['database']['host'], :username => 'root', :password => node['mysql']['server_root_password']}
+# Get mysql root password from databag secrets
+mysql_secrets = Chef::EncryptedDataBagItem.load("secrets", "mysql")
+mysql_root_pass = mysql_secrets[node.chef_environment]['root']
+
+
+mysql_connection_info = {:host => node['otrs']['database']['host'], :username => 'root', :password => :mysql_root_pass}
 
 
 begin


### PR DESCRIPTION
Hi,

the first commit was a minor fix to recipes/default.rb to fix a chef run failure caused by DeleteSessionIDs cron it was missing a value from minutes.

the rest is some changes to support a remote mysql server I removed the call from include mysql::server then refractored to use a dba account for database creation.
I think this should really use a databag to that but have just used a attribute at the minute.

also both the otrs version and this cookbook version were increased
